### PR TITLE
Remove nightly requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 #![cfg_attr(not(doctest), doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md")))]
 
 pub mod fifo;

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -129,7 +129,7 @@ mod test {
     #[async_std::test]
     async fn test_who_am_i_async() {
         let expectations: &[SpiTransaction<u8>] = &[
-            SpiTransaction::transfer(vec![0x75 | 0x80], vec![0x12, 0x47]),
+            SpiTransaction::transfer_in_place(vec![0x75 | 0x80, 0x00], vec![0x12, 0x47]),
             SpiTransaction::flush(),
         ];
 


### PR DESCRIPTION
Changes the async register read/modify to use `transfer_in_place`. Not sure why the blocking api used `transfer_in_place` but the async api didn't.