### PR TITLE
Read packet4

### DIFF
--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -7,17 +7,29 @@ use bytemuck::{AnyBitPattern, NoUninit};
 pub enum Timestamp {
     /// No timestamp provided.
     None,
-    /// Datasheet: Packet contains ODR timestamp, with 16µs resolution. The
-    /// timestamp is absolute and monotonically increases. To compute
-    /// deltas between packets or perform unwrapping, use two-complement
-    /// subtraction.
+    /// Packet contains an ODR (Output Data Rate) timestamp with 16µs
+    /// resolution.
+    ///
+    /// The nature of this timestamp (absolute vs. delta) is determined by the
+    /// [`Config::timestamps_are_absolute`](crate::Config::timestamps_are_absolute) setting during initialization.
+    ///
+    /// - If `timestamps_are_absolute` is `true`, this is an absolute,
+    ///   monotonically increasing timestamp that wraps around on the `u16`
+    ///   boundary. To compute deltas between packets or perform unwrapping,
+    ///   use two's-complement
+    //    subtraction (e.g., `(new.wrapping_sub(old)) as i16`).
+    ///
+    /// - If `timestamps_are_absolute` is `false` (the default), this value
+    ///   represents the time delta since the last ODR.
     OdrTimestamp(u16),
-    /// Datasheet: Packet contains FSYNC time, and this packet is flagged as
-    /// first ODR after FSYNC (only if FIFO_TMST_FSYNC_EN).
+    /// Packet contains an FSYNC timestamp.
+    ///
+    /// This indicates the time of an FSYNC event and flags the packet as the
+    /// first ODR after FSYNC. This is only enabled if `FIFO_TMST_FSYNC_EN` is
+    /// set.
     ///
     /// This implementation does not configure FIFO_TMST_FSYNC_EN as 1, so
     /// getting this response is unexpected.
-    /// The unit is unclear from the data sheet.
     FsyncTimestamp(u16),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,11 @@ pub enum Error<BusError> {
     /// This indicates either the wrong device or a communication issue.
     /// The stored u8 indicates the returned response from the device.
     WhoAmIMismatch(u8),
+
+    /// The code has been to slow in reading samples out of the FIFO. The
+    /// user is recommended to mitigate by restarting the device if this
+    /// happens.
+    FifoOverflow,
 }
 
 /// Helper trait to convert bus errors into our top-level Error::Bus variant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub enum Error<BusError> {
     /// This indicates either the wrong device or a communication issue.
     /// The stored u8 indicates the returned response from the device.
     WhoAmIMismatch(u8),
+
+    /// A sample read did not result in a read sample.
+    NoSampleRead,
 }
 
 /// Helper trait to convert bus errors into our top-level Error::Bus variant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod register_bank;
 pub mod uninitialized;
 
 // Reexports.
+pub use fifo::{Sample, Timestamp};
 pub use uninitialized::{
     Config, InterruptMode, InterruptPolarity, OutputDataRate,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,6 @@ pub enum Error<BusError> {
     /// This indicates either the wrong device or a communication issue.
     /// The stored u8 indicates the returned response from the device.
     WhoAmIMismatch(u8),
-
-    /// A sample read did not result in a read sample.
-    NoSampleRead,
 }
 
 /// Helper trait to convert bus errors into our top-level Error::Bus variant.

--- a/src/ready.rs
+++ b/src/ready.rs
@@ -76,31 +76,77 @@ where
     }
 
     #[cfg(feature = "async")]
-    pub async fn read_sample(&mut self) -> Result<Sample, Error<SPI::Error>> {
-        // Read one extra packet (discarded) in case the user has been slow in
-        // reading out samples.
+    /// Reads and parses a single sample from the FIFO.
+    ///
+    /// This function performs an efficient single SPI transaction to read the
+    /// interrupt status, FIFO count, and the next available FIFO packet. It
+    /// then parses this packet into a [`Sample`].
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some((sample, more_data)))`: On a successful read and parse.
+    ///   - `sample`: The [`Sample`] containing sensor data.
+    ///   - `more_data`: A boolean flag that is `true` if the FIFO contains more
+    ///     packets to be read.
+    /// - `Ok(None)`: If the FIFO was empty or the packet read was invalid
+    ///   (e.g., an "empty" marker).
+    /// - `Err(Error::Bus(_))`: If a communication error occurs on the SPI bus.
+    pub async fn read_sample(
+        &mut self,
+    ) -> Result<Option<(Sample, bool)>, Error<SPI::Error>> {
         // We read INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, and then the data in
         // one go. The leading byte in the buffer is used to signal register
         // address, it's output doesn't contain data on return.
-        let mut buffer = [0u8; 44];
+        let mut buffer = [0u8; 4 + core::mem::size_of::<FifoPacket4>()];
         buffer[0] = crate::register_bank::bank0::INT_STATUS::ID | 0x80;
         self.ll.bus.transfer_in_place(&mut buffer).await?;
+        // Buffer now contains [0, INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, DATA,
+        // DATA, ...]
         let p = bytemuck::from_bytes::<FifoPacket4>(&buffer[4..24]);
-        Self::sample_from_packet4(p).ok_or(Error::NoSampleRead)
+        let fifo_count = ((buffer[2] as u16) << 8) | (buffer[3] as u16);
+        Ok(Self::sample_from_packet4(p).map(|sample| {
+            (
+                sample,
+                fifo_count > core::mem::size_of::<FifoPacket4>() as u16,
+            )
+        }))
     }
 
     #[cfg(not(feature = "async"))]
-    pub fn read_sample(&mut self) -> Result<Sample, Error<SPI::Error>> {
-        // Read one extra packet (discarded) in case the user has been slow in
-        // reading out samples.
+    /// Reads and parses a single sample from the FIFO.
+    ///
+    /// This function performs an efficient single SPI transaction to read the
+    /// interrupt status, FIFO count, and the next available FIFO packet. It
+    /// then parses this packet into a [`Sample`].
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some((sample, more_data)))`: On a successful read and parse.
+    ///   - `sample`: The [`Sample`] containing sensor data.
+    ///   - `more_data`: A boolean flag that is `true` if the FIFO contains more
+    ///     packets to be read.
+    /// - `Ok(None)`: If the FIFO was empty or the packet read was invalid
+    ///   (e.g., an "empty" marker).
+    /// - `Err(Error::Bus(_))`: If a communication error occurs on the SPI bus.
+    pub fn read_sample(
+        &mut self,
+    ) -> Result<Option<(Sample, bool)>, Error<SPI::Error>> {
         // We read INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, and then the data in
         // one go. The leading byte in the buffer is used to signal register
         // address, it's output doesn't contain data on return.
-        let mut buffer = [0u8; 44];
+        let mut buffer = [0u8; 4 + core::mem::size_of::<FifoPacket4>()];
         buffer[0] = crate::register_bank::bank0::INT_STATUS::ID | 0x80;
         self.ll.bus.transfer_in_place(&mut buffer)?;
+        // Buffer now contains [0, INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, DATA,
+        // DATA, ...]
         let p = bytemuck::from_bytes::<FifoPacket4>(&buffer[4..24]);
-        Self::sample_from_packet4(p).ok_or(Error::NoSampleRead)
+        let fifo_count = ((buffer[2] as u16) << 8) | (buffer[3] as u16);
+        Ok(Self::sample_from_packet4(p).map(|sample| {
+            (
+                sample,
+                fifo_count > core::mem::size_of::<FifoPacket4>() as u16,
+            )
+        }))
     }
 
     fn sample_from_packet4(p: &FifoPacket4) -> Option<Sample> {

--- a/src/ready.rs
+++ b/src/ready.rs
@@ -102,7 +102,7 @@ where
         self.ll.bus.transfer_in_place(&mut buffer).await?;
         // Buffer now contains [0, INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, DATA,
         // DATA, ...]
-        let int_status = int_status::R([buffer[1], 1]);
+        let int_status = int_status::R([0, buffer[1]]);
         if int_status.fifo_full_int() != 0 {
             return Err(Error::FifoOverflow);
         }
@@ -143,7 +143,7 @@ where
         self.ll.bus.transfer_in_place(&mut buffer)?;
         // Buffer now contains [0, INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, DATA,
         // DATA, ...]
-        let int_status = int_status::R([buffer[1], 1]);
+        let int_status = int_status::R([0, buffer[1]]);
         if int_status.fifo_full_int() != 0 {
             return Err(Error::FifoOverflow);
         }

--- a/src/ready.rs
+++ b/src/ready.rs
@@ -4,7 +4,11 @@ use embedded_hal_async::spi::SpiDevice;
 #[cfg(not(feature = "async"))]
 use embedded_hal::spi::SpiDevice;
 
-use crate::{register_bank::Register, Ready, ICM42688};
+use crate::{
+    fifo::{FifoPacket4, Sample},
+    register_bank::Register,
+    Error, Ready, ICM42688,
+};
 
 impl<SPI> ICM42688<SPI, Ready>
 where
@@ -69,6 +73,67 @@ where
         let fifo_count = ((buffer[2] as u16) << 8) | (buffer[3] as u16);
 
         Ok(fifo_count as usize / 20)
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn read_sample(&mut self) -> Result<Sample, Error<SPI::Error>> {
+        // Read 1 extra packet in case the user has been slow in reading out samples.
+        let mut buffer = [0u8; 44];
+        // We read INT_STATUS, FIFO_COUNT_H, FIFO_COUNT_L, and then the data in
+        // one go.
+        buffer[0] = crate::register_bank::bank0::INT_STATUS::ID | 0x80;
+        self.ll.bus.transfer_in_place(&mut buffer).await?;
+        let p = bytemuck::from_bytes::<FifoPacket4>(&buffer[4..24]);
+        Self::sample_from_packet4(p).ok_or(Error::NoSampleRead)
+    }
+
+    #[cfg(not(feature = "async"))]
+    pub fn read_sample(&mut self) -> Result<Sample, Error<SPI::Error>> {
+        let mut buffer = [0u8; 44];
+        buffer[0] = crate::register_bank::bank0::INT_STATUS::ID | 0x80;
+        self.ll.bus.transfer_in_place(&mut buffer)?;
+        let p = bytemuck::from_bytes::<FifoPacket4>(&buffer[4..24]);
+        Self::sample_from_packet4(p).ok_or(Error::NoSampleRead)
+    }
+
+    fn sample_from_packet4(p: &FifoPacket4) -> Option<Sample> {
+        (p.fifo_header().header_msg().value() == 0).then(|| {
+            let gyro = (p.fifo_header().has_gyro().value() != 0).then(|| {
+                let gx = p.gyro_data_x();
+                let gy = p.gyro_data_y();
+                let gz = p.gyro_data_z();
+                // Packet 4 => full scale reading.
+                // The signed 20-bit quantity corresponds to ±2000 degrees per
+                // second. 1 degree = π/180 radians.
+                let scale = core::f32::consts::PI / 180.0 * 2000.0f32
+                    / (1 << 19) as f32;
+                (gx as f32 * scale, gy as f32 * scale, gz as f32 * scale)
+            });
+            let accel = (p.fifo_header().has_accel().value() != 0).then(|| {
+                let ax = p.accel_data_x();
+                let ay = p.accel_data_y();
+                let az = p.accel_data_z();
+                // Packet 4 => full scale reading.
+                // The signed 20-bit quantity corresponds to ±16g.
+                let std_gravity = 9.80665;
+                let scale = std_gravity * 16.0f32 / (1 << 19) as f32;
+                (ax as f32 * scale, ay as f32 * scale, az as f32 * scale)
+            });
+            // Temperature is always provided.
+            let temp_scale = 1f32 / 2.07;
+            let temperature_celsius =
+                p.temperature_raw() as f32 * temp_scale + 25.0;
+            let timestamp = (p.fifo_header().has_timestamp_fsync().value()
+                != 0)
+                .then_some(p.timestamp());
+
+            Sample {
+                accel,
+                gyro,
+                temperature_celsius,
+                timestamp,
+            }
+        })
     }
 
     #[cfg(not(feature = "async"))]

--- a/src/uninitialized.rs
+++ b/src/uninitialized.rs
@@ -241,8 +241,6 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
             .accel_config1()
             .async_modify(|_, w| w.accel_ui_filt_ord(0b0))
             .await?;
-        // To support occasional packet dropping, we configure timestamping
-        // without deltas and leave delta computation to the user.
         bank0
             .tmst_config()
             .async_modify(|_, w| {
@@ -429,8 +427,6 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         bank0
             .accel_config1()
             .modify(|_, w| w.accel_ui_filt_ord(0b0))?;
-        // To support occasional packet dropping, we configure timestamping
-        // without deltas and leave delta computation to the user.
         bank0.tmst_config().modify(|_, w| {
             w.tmst_en(1)
                 .tmst_delta_en((!config.timestamps_are_absolute) as u8)

--- a/src/uninitialized.rs
+++ b/src/uninitialized.rs
@@ -230,11 +230,13 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
             .accel_config1()
             .async_modify(|_, w| w.accel_ui_filt_ord(0b0))
             .await?;
+        // To support occasional packet dropping, we configure timestamping
+        // without deltas and leave delta computation to the user.
         bank0
             .tmst_config()
             .async_modify(|_, w| {
                 w.tmst_en(1)
-                    .tmst_delta_en(1)
+                    .tmst_delta_en(0)
                     .tmst_to_regs_en(1)
                     .tmst_res(1)
                     .tmst_fsync_en(0)
@@ -342,7 +344,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         self.ll
             .bank::<0>()
             .pwr_mgmt0()
-            .async_modify(|_, w| w.gyro_mode(0b11).accel_mode(0b11))
+            .async_modify(|_, w| w.gyro_mode(0b11).accel_mode(0b11).temp_dis(0))
             .await?;
 
         // Delay for 200us per the datasheet after writing to PWR_MGMT0
@@ -416,9 +418,11 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         bank0
             .accel_config1()
             .modify(|_, w| w.accel_ui_filt_ord(0b0))?;
+        // To support occasional packet dropping, we configure timestamping
+        // without deltas and leave delta computation to the user.
         bank0.tmst_config().modify(|_, w| {
             w.tmst_en(1)
-                .tmst_delta_en(1)
+                .tmst_delta_en(0)
                 .tmst_to_regs_en(1)
                 .tmst_res(1)
                 .tmst_fsync_en(0)
@@ -492,7 +496,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         self.ll
             .bank::<0>()
             .pwr_mgmt0()
-            .modify(|_, w| w.gyro_mode(0b11).accel_mode(0b11))?;
+            .modify(|_, w| w.gyro_mode(0b11).accel_mode(0b11).temp_dis(0))?;
 
         // Delay for 200us per the datasheet after writing to PWR_MGMT0
         delay.delay_us(200);


### PR DESCRIPTION
Add read_sample method for parsing FIFO data

This commit introduces a new read_sample method to read and parse a single data sample from the sensor's FIFO.

This involves several key additions:

- fifo::Sample struct: A new public struct Sample is added to hold parsed FIFO data. It contains optional fields for accel (m/s²) , gyro (rad/s) , and timestamp (16 µs units) , along with a non-optional temperature_celsius (°C) field. The fields are optional because their presence depends on the FIFO packet's header flags.
- read_sample method: Added to ICM42688<SPI, Ready> in both async and non-async (blocking) variants . This method reads a 44-byte buffer (starting from INT_STATUS to get status, count, and data) , parses the data as a FifoPacket4, and converts it into a Sample.
- sample_from_packet4 helper: A new private function is added to perform the conversion from a raw FifoPacket4 to an Option<Sample> .
- Error::NoSampleRead: A new error variant is added and returned by read_sample if the FIFO packet is empty (i.e., header_msg bit is set).
- FifoHeader visibility: Fields has_timestamp_fsync , has_gyro , has_accel , and header_msg  are made pub(crate) to be accessible from the new parsing logic in ready.rs.
