### PR TITLE
Add ICM-42686-P support via generic Device parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a platform agnostic Rust driver for the ICM-426xx 6-axis motion sensor u
 Currently supported devices:
 
 - ICM-42688-P
+- ICM-42686-P
 
 We support both the I2C and SPI interface, but currently only the SPI interface is tested. PRs are welcome!
 
@@ -30,8 +31,13 @@ async fn main() {
     let spidev =
         embedded_hal_bus::spi::ExclusiveDevice::new_no_delay(spi, pin.clone()).unwrap();
 
+    // For ICM-42688-P (default):
     let mut icm = icm426xx::ICM42688::new(spidev);
     let mut icm = icm.initialize(Delay).await.unwrap();
+
+    // For ICM-42686-P, use the type alias instead:
+    // let mut icm = icm426xx::ICM42686::new(spidev);
+
     let mut bank = icm.ll().bank::<{ icm426xx::register_bank::BANK0 }>();
 
     // print WHO_AM_I register

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![cfg_attr(not(doctest), doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md")))]
 
+use core::marker::PhantomData;
+
 pub mod fifo;
 pub mod ll;
 pub mod ready;
@@ -43,7 +45,53 @@ impl<BusError> From<BusError> for Error<BusError> {
     }
 }
 
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Trait describing a specific device variant in the ICM-426xx family.
+///
+/// This trait is sealed and cannot be implemented outside of this crate.
+pub trait Device: sealed::Sealed {
+    /// Expected WHO_AM_I register value.
+    const WHO_AM_I: u8;
+    /// Full-scale gyroscope range in degrees per second (for 20-bit FIFO mode).
+    const GYRO_FULL_SCALE_DPS: f32;
+    /// Full-scale accelerometer range in g (for 20-bit FIFO mode).
+    const ACCEL_FULL_SCALE_G: f32;
+}
+
+/// Marker type for the ICM-42688-P variant.
+///
+/// WHO_AM_I = 0x47, gyro ±2000 dps, accel ±16g.
+pub struct Icm42688p;
+
+impl sealed::Sealed for Icm42688p {}
+impl Device for Icm42688p {
+    const WHO_AM_I: u8 = 0x47;
+    const GYRO_FULL_SCALE_DPS: f32 = 2000.0;
+    const ACCEL_FULL_SCALE_G: f32 = 16.0;
+}
+
+/// Marker type for the ICM-42686-P variant.
+///
+/// WHO_AM_I = 0x44, gyro ±4000 dps, accel ±32g.
+pub struct Icm42686p;
+
+impl sealed::Sealed for Icm42686p {}
+impl Device for Icm42686p {
+    const WHO_AM_I: u8 = 0x44;
+    const GYRO_FULL_SCALE_DPS: f32 = 4000.0;
+    const ACCEL_FULL_SCALE_G: f32 = 32.0;
+}
+
+/// Type alias for the ICM-42686-P variant.
+pub type ICM42686<SPI, State> = ICM42688<SPI, State, Icm42686p>;
+
 /// ICM42688 top-level driver
+///
+/// The `D` type parameter selects the device variant and defaults to
+/// [`Icm42688p`]. Use [`Icm42686`] (a type alias) for the ICM-42686-P.
 ///
 /// Usage:
 ///
@@ -72,7 +120,8 @@ impl<BusError> From<BusError> for Error<BusError> {
 ///     }
 /// }
 /// ```
-pub struct ICM42688<SPI, State> {
+pub struct ICM42688<SPI, State, D: Device = Icm42688p> {
     ll: crate::ll::ICM42688<SPI>,
     _state: State,
+    _device: PhantomData<D>,
 }

--- a/src/ready.rs
+++ b/src/ready.rs
@@ -7,10 +7,10 @@ use embedded_hal::spi::SpiDevice;
 use crate::{
     fifo::{FifoPacket4, Sample},
     register_bank::{bank0::int_status, Register},
-    Error, Ready, ICM42688,
+    Device, Error, Ready, ICM42688,
 };
 
-impl<SPI> ICM42688<SPI, Ready>
+impl<SPI, D: Device> ICM42688<SPI, Ready, D>
 where
     SPI: SpiDevice,
 {
@@ -158,10 +158,10 @@ where
                 let gy = p.gyro_data_y();
                 let gz = p.gyro_data_z();
                 // Packet 4 => full scale reading.
-                // The signed 20-bit quantity corresponds to ±2000 degrees per
-                // second. 1 degree = π/180 radians.
-                const FULL_SCALE_DPS: f32 = 2000.0;
-                let scale = core::f32::consts::PI / 180.0 * FULL_SCALE_DPS / FULL_1SIDE_RANGE;
+                // The signed 20-bit quantity corresponds to the device's
+                // full-scale gyro range. 1 degree = π/180 radians.
+                let scale =
+                    core::f32::consts::PI / 180.0 * D::GYRO_FULL_SCALE_DPS / FULL_1SIDE_RANGE;
                 (gx as f32 * scale, gy as f32 * scale, gz as f32 * scale)
             });
             let accel = (p.fifo_header().has_accel().value() != 0).then(|| {
@@ -169,10 +169,10 @@ where
                 let ay = p.accel_data_y();
                 let az = p.accel_data_z();
                 // Packet 4 => full scale reading.
-                // The signed 20-bit quantity corresponds to ±16g.
+                // The signed 20-bit quantity corresponds to the device's
+                // full-scale accel range.
                 const STD_GRAVITY: f32 = 9.80665;
-                const FULL_SCALE_G: f32 = 16.0;
-                let scale = STD_GRAVITY * FULL_SCALE_G / FULL_1SIDE_RANGE;
+                let scale = STD_GRAVITY * D::ACCEL_FULL_SCALE_G / FULL_1SIDE_RANGE;
                 (ax as f32 * scale, ay as f32 * scale, az as f32 * scale)
             });
             // Temperature is always provided.

--- a/src/uninitialized.rs
+++ b/src/uninitialized.rs
@@ -6,7 +6,9 @@ use embedded_hal_async::delay::DelayNs;
 #[cfg(not(feature = "async"))]
 use embedded_hal::delay::DelayNs;
 
-use crate::{Error, Ready, Uninitialized, ICM42688};
+use core::marker::PhantomData;
+
+use crate::{Device, Error, Ready, Uninitialized, ICM42688};
 
 /// Determines how the interrupt signal is generated.
 ///
@@ -91,11 +93,12 @@ impl Default for Config {
     }
 }
 
-impl<SPI> ICM42688<SPI, Uninitialized> {
+impl<SPI, D: Device> ICM42688<SPI, Uninitialized, D> {
     pub fn new(spi: SPI) -> Self {
         ICM42688 {
             ll: crate::ll::ICM42688::new(spi),
             _state: Uninitialized,
+            _device: PhantomData,
         }
     }
 
@@ -165,7 +168,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         mut self,
         mut delay: impl DelayNs,
         config: Config,
-    ) -> Result<ICM42688<SPI, Ready>, Error<SPI::Error>>
+    ) -> Result<ICM42688<SPI, Ready, D>, Error<SPI::Error>>
     where
         SPI: embedded_hal_async::spi::SpiDevice,
     {
@@ -186,7 +189,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
 
         // Read the WHO_AM_I register to verify the device is present
         let who_am_i = bank0.who_am_i().async_read().await?.value();
-        if who_am_i != 0x47 {
+        if who_am_i != D::WHO_AM_I {
             return Err(Error::WhoAmIMismatch(who_am_i));
         }
 
@@ -359,6 +362,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         Ok(ICM42688 {
             ll: self.ll,
             _state: Ready,
+            _device: PhantomData,
         })
     }
 
@@ -367,7 +371,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         mut self,
         mut delay: impl DelayNs,
         config: Config,
-    ) -> Result<ICM42688<SPI, Ready>, Error<SPI::Error>>
+    ) -> Result<ICM42688<SPI, Ready, D>, Error<SPI::Error>>
     where
         SPI: embedded_hal::spi::SpiDevice,
     {
@@ -387,7 +391,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
 
         // Read the WHO_AM_I register to verify the device is present
         let who_am_i = bank0.who_am_i().read()?.value();
-        if who_am_i != 0x47 {
+        if who_am_i != D::WHO_AM_I {
             return Err(Error::WhoAmIMismatch(who_am_i));
         }
 
@@ -508,6 +512,7 @@ impl<SPI> ICM42688<SPI, Uninitialized> {
         Ok(ICM42688 {
             ll: self.ll,
             _state: Ready,
+            _device: PhantomData,
         })
     }
 


### PR DESCRIPTION
Introduces a sealed Device trait so the driver can handle both the ICM-42688-P and ICM-42686-P. The two chips share a register map but differ in WHO_AM_I (0x47 vs 0x44) and 20-bit FIFO full-scale ranges (2000 dps / 16g vs 4000 dps / 32g).

ICM42688 gains a third type parameter D: Device = Icm42688p, keeping all existing code compatible. ICM-42686-P users can use the ICM42686 type alias